### PR TITLE
Patch to fix temporary files leakage and minor updates

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,11 +6,11 @@ pkgdesc="Custom STL thumbnails for Tumbler"
 arch=('any')
 url="https://github.com/j-james/thunar-stl-thumbnails"
 license=('BSD')
-depends=('tumbler' 'openscad')
+depends=('tumbler' 'openscad' 'imagemagick')
 source=('stl.thumbnailer'
 		'stl-thumbnailer.sh')
 sha256sums=('fd4a8c44e4a35418e894241a3e6fefcab83279570b5e91296dde1f1179b0a0cc'
-			'0b6a39b7facae2c7d036a0017010a86f6a3ebcb2a572312174d7d4cff1af8325')
+            '998ba171b426278a168c16f480b4eb975c6b91552020199525ac554cb9d2696a')
 
 package() {
 	install -Dvm644 "stl.thumbnailer" "$pkgdir/usr/share/thumbnailers/stl.thumbnailer"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # thunar-stl-thumbnails
 
-Generate thumbnails for STLs with Tumbler. Requires OpenSCAD to be installed.
+Generate thumbnails for STLs with Tumbler. Requires OpenSCAD and ImageMagick to be installed.
 
 ![thunar](https://user-images.githubusercontent.com/35242550/182044826-e9520fed-98f5-47e9-8000-ea5c9ea56e3e.png)

--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 Generate thumbnails for STLs with Tumbler. Requires OpenSCAD and ImageMagick to be installed.
 
 ![thunar](https://user-images.githubusercontent.com/35242550/182044826-e9520fed-98f5-47e9-8000-ea5c9ea56e3e.png)
+
+
+NOTE: Remember to run `systemctl --user restart tumblerd` and restart Thunar to apply changes.

--- a/stl-thumbnailer.sh
+++ b/stl-thumbnailer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $# -lt 3 ]]; then
 	echo "$0: input_file_name output_file_name size"

--- a/stl-thumbnailer.sh
+++ b/stl-thumbnailer.sh
@@ -10,11 +10,15 @@ OUTPUT_FILE=$2
 SIZE=$3
 
 TEMP="$(mktemp --directory --tmpdir tumbler-stl-XXXXXXX)"
-cp "$INPUT_FILE" "$TEMP/source.stl"
+# Use a sub shell to enclose the commands in case it aborts and skip the last cleanup action
+# Sub shell BEG
+(
+	cp "$INPUT_FILE" "$TEMP/source.stl"
 
-echo "import(\"source.stl\", convexity=10);" > "$TEMP/thumbnail.scad"
-openscad --imgsize "500,500" -o "$TEMP/thumbnail.png" "$TEMP/thumbnail.scad" 2>/dev/null
+	echo "import(\"source.stl\", convexity=10);" >"$TEMP/thumbnail.scad"
+	openscad --imgsize "500,500" -o "$TEMP/thumbnail.png" "$TEMP/thumbnail.scad" 2>/dev/null
 
-convert -thumbnail "$SIZE" "$TEMP/thumbnail.png" "$OUTPUT_FILE" 1>/dev/null 2>&1
-
-rm -rf $TEMP
+	convert -thumbnail "$SIZE" "$TEMP/thumbnail.png" "$OUTPUT_FILE" 1>/dev/null 2>&1
+)
+# Sub shell END
+[ -d $TEMP ] && rm -rf $TEMP

--- a/stl-thumbnailer.sh
+++ b/stl-thumbnailer.sh
@@ -8,11 +8,13 @@ fi
 INPUT_FILE=$1
 OUTPUT_FILE=$2
 SIZE=$3
+MEM_LIMIT_KiB=$(( 300 * 1024 )) # Limit the memory usage to 300 MiB
 
 TEMP="$(mktemp --directory --tmpdir tumbler-stl-XXXXXXX)"
 # Use a sub shell to enclose the commands in case it aborts and skip the last cleanup action
 # Sub shell BEG
 (
+	ulimit -v $MEM_LIMIT_KiB
 	cp "$INPUT_FILE" "$TEMP/source.stl"
 
 	echo "import(\"source.stl\", convexity=10);" >"$TEMP/thumbnail.scad"


### PR DESCRIPTION
Use a sub shell syntax to enclose sub routines to prevent unexpected aborts skipping last cleanup command.